### PR TITLE
Add basic .vscode/tasks.json

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,40 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "Run native dev",
+			"type": "cargo",
+			"command": "run",
+			"options": {
+				"env": {
+					"RUST_BACKTRACE": "full"
+				}
+			},
+			"presentation": {
+				"clear": true
+			},
+			"problemMatcher": [
+				"$rustc"
+			],
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			}
+		},
+		{
+			"label": "Run native release",
+			"type": "cargo",
+			"command": "run",
+			"args": [
+				"--release"
+			],
+			"presentation": {
+				"clear": true
+			},
+			"problemMatcher": [
+				"$rustc"
+			],
+			"group": "build"
+		}
+	]
+}


### PR DESCRIPTION
Fixes https://github.com/TheBevyFlock/bevy-template/issues/7.

We may need to update this file if we make changes to `Cargo.toml`. IMO whatever change we make, `cargo run` should still default to a native dev build. The args for a release build may change, though.