### PR TITLE
Optimize dev experience for different targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/wasm

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,24 @@
 [package]
-name = "bevy_github_ci_template"
+name = "bevy_template"
 version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0 OR CC0-1.0"
+
+[dependencies]
+bevy = "0.14.0"
+
+[target.'cfg(target_family = "wasm")'.dependencies]
+wasm-bindgen = "0.2"
+
+# The following block tweaks Bevy's features according to our build environment
+
+[dev-dependencies.bevy]
+version = "0.14.0"
+features = ["dynamic_linking"]
+
+[target.'cfg(not(target_family = "wasm"))'.dev-dependencies.bevy]
+version = "0.14.0"
+features = ["file_watcher", "embedded_watcher"]
 
 # Compile with Performance Optimizations:
 # https://bevyengine.org/learn/book/getting-started/setup/#compile-with-performance-optimizations
@@ -14,6 +30,3 @@ opt-level = 1
 # Enable high optimizations for dependencies (incl. Bevy), but not for our code:
 [profile.dev.package."*"]
 opt-level = 3
-
-[dependencies]
-bevy = "0.12"

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,11 +11,13 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        // Wasm builds will check for meta files (that don't exist) if this isn't set.
-        // This causes errors and even panics on web build on itch.
-        // See https://github.com/bevyengine/bevy_github_ci_template/issues/48.
-        .insert_resource(AssetMetaCheck::Never)
-        .add_plugins(DefaultPlugins)
+        .add_plugins(DefaultPlugins.set(AssetPlugin {
+            // Wasm builds will check for meta files (that don't exist) if this isn't set.
+            // This causes errors and even panics on web build on itch.
+            // See https://github.com/bevyengine/bevy_github_ci_template/issues/48.
+            meta_check: AssetMetaCheck::Never,
+            ..default()
+        }))
         .add_systems(Startup, setup)
         .run();
 }


### PR DESCRIPTION
Alternative to #20 and #18
I'd prefer to keep a `dev` feature out until we can't avoid it in order to make it as simple as possible to use the template without fiddling with features.