### PR TITLE
Remove `wasm-bindgen` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,6 @@ bevy = "0.14"
 # Disable low-severity logs at compile time for performance.
 log = { version = "0.4", features = ["max_level_debug", "release_max_level_warn"] }
 
-[target.'cfg(target_family = "wasm")'.dependencies]
-wasm-bindgen = "0.2"
-
 [features]
 default = [
     # Default to a native dev build.


### PR DESCRIPTION
Turns out it's not actually needed. I tested this on itch.io with my own template.

We'll still need to use `wasm-bindgen-cli` to build for web, but only as a CLI tool, not as a build dependency.