### PR TITLE
Refactor `util/ui/` and add prelude

### DIFF
--- a/src/screen/credits.rs
+++ b/src/screen/credits.rs
@@ -33,7 +33,7 @@ fn enter_credits(mut commands: Commands) {
 
 fn handle_credits_action(
     mut next_screen: ResMut<NextState<Screen>>,
-    mut button_query: InteractionQuery<CreditsAction>,
+    mut button_query: InteractionQuery<&CreditsAction>,
 ) {
     for (interaction, action) in &mut button_query {
         if matches!(interaction, Interaction::Pressed) {

--- a/src/screen/credits.rs
+++ b/src/screen/credits.rs
@@ -3,7 +3,7 @@
 use bevy::prelude::*;
 
 use super::Screen;
-use crate::util::ui::*;
+use crate::util::ui::prelude::*;
 
 pub(super) fn plugin(app: &mut App) {
     app.add_systems(OnEnter(Screen::Credits), enter_credits);

--- a/src/screen/credits.rs
+++ b/src/screen/credits.rs
@@ -33,7 +33,7 @@ fn enter_credits(mut commands: Commands) {
 
 fn handle_credits_action(
     mut next_screen: ResMut<NextState<Screen>>,
-    mut button_query: ButtonInteractionQuery<CreditsAction>,
+    mut button_query: InteractionQuery<CreditsAction>,
 ) {
     for (interaction, action) in &mut button_query {
         if matches!(interaction, Interaction::Pressed) {

--- a/src/screen/title.rs
+++ b/src/screen/title.rs
@@ -3,7 +3,7 @@
 use bevy::prelude::*;
 
 use super::Screen;
-use crate::util::ui::*;
+use crate::util::ui::prelude::*;
 
 pub(super) fn plugin(app: &mut App) {
     app.add_systems(OnEnter(Screen::Title), enter_title);

--- a/src/screen/title.rs
+++ b/src/screen/title.rs
@@ -29,7 +29,7 @@ fn enter_title(mut commands: Commands) {
 
 fn handle_title_action(
     mut next_screen: ResMut<NextState<Screen>>,
-    mut button_query: ButtonInteractionQuery<TitleAction>,
+    mut button_query: InteractionQuery<TitleAction>,
 ) {
     for (interaction, action) in &mut button_query {
         if matches!(interaction, Interaction::Pressed) {

--- a/src/screen/title.rs
+++ b/src/screen/title.rs
@@ -29,7 +29,7 @@ fn enter_title(mut commands: Commands) {
 
 fn handle_title_action(
     mut next_screen: ResMut<NextState<Screen>>,
-    mut button_query: InteractionQuery<TitleAction>,
+    mut button_query: InteractionQuery<&TitleAction>,
 ) {
     for (interaction, action) in &mut button_query {
         if matches!(interaction, Interaction::Pressed) {

--- a/src/util/ui/interaction.rs
+++ b/src/util/ui/interaction.rs
@@ -5,7 +5,7 @@ pub(super) fn plugin(app: &mut App) {
 }
 
 pub(crate) type InteractionQuery<'w, 's, T> =
-    Query<'w, 's, (&'static Interaction, &'static T), Changed<Interaction>>;
+    Query<'w, 's, (&'static Interaction, T), Changed<Interaction>>;
 
 /// Palette for widget interactions.
 #[derive(Component)]
@@ -26,12 +26,9 @@ impl InteractionPalette {
 }
 
 fn apply_interaction_palette(
-    mut interaction_query: Query<
-        (&Interaction, &InteractionPalette, &mut BackgroundColor),
-        Changed<Interaction>,
-    >,
+    mut palette_query: InteractionQuery<(&InteractionPalette, &mut BackgroundColor)>,
 ) {
-    for (interaction, palette, mut background) in &mut interaction_query {
+    for (interaction, (palette, mut background)) in &mut palette_query {
         *background = match interaction {
             Interaction::None => palette.none,
             Interaction::Hovered => palette.hovered,

--- a/src/util/ui/interaction.rs
+++ b/src/util/ui/interaction.rs
@@ -1,8 +1,11 @@
 use bevy::prelude::*;
 
 pub(super) fn plugin(app: &mut App) {
-    app.add_systems(Update, update);
+    app.add_systems(Update, apply_interaction_palette);
 }
+
+pub(crate) type ButtonInteractionQuery<'w, 's, 'a, T> =
+    Query<'w, 's, (&'a Interaction, &'a T), (Changed<Interaction>, With<Button>)>;
 
 /// Palette for widget interactions.
 #[derive(Component)]
@@ -22,7 +25,7 @@ impl InteractionPalette {
     }
 }
 
-fn update(
+fn apply_interaction_palette(
     mut interaction_query: Query<
         (&mut BackgroundColor, &Interaction, &InteractionPalette),
         (Changed<Interaction>, With<Button>),

--- a/src/util/ui/interaction.rs
+++ b/src/util/ui/interaction.rs
@@ -4,8 +4,8 @@ pub(super) fn plugin(app: &mut App) {
     app.add_systems(Update, apply_interaction_palette);
 }
 
-pub(crate) type ButtonInteractionQuery<'w, 's, 'a, T> =
-    Query<'w, 's, (&'a Interaction, &'a T), (Changed<Interaction>, With<Button>)>;
+pub(crate) type ButtonInteractionQuery<'w, 's, T> =
+    Query<'w, 's, (&'static Interaction, &'static T), (Changed<Interaction>, With<Button>)>;
 
 /// Palette for widget interactions.
 #[derive(Component)]
@@ -27,11 +27,11 @@ impl InteractionPalette {
 
 fn apply_interaction_palette(
     mut interaction_query: Query<
-        (&mut BackgroundColor, &Interaction, &InteractionPalette),
+        (&Interaction, &InteractionPalette, &mut BackgroundColor),
         (Changed<Interaction>, With<Button>),
     >,
 ) {
-    for (mut background, interaction, palette) in &mut interaction_query {
+    for (interaction, palette, mut background) in &mut interaction_query {
         *background = match interaction {
             Interaction::None => palette.none,
             Interaction::Hovered => palette.hovered,

--- a/src/util/ui/interaction.rs
+++ b/src/util/ui/interaction.rs
@@ -4,8 +4,8 @@ pub(super) fn plugin(app: &mut App) {
     app.add_systems(Update, apply_interaction_palette);
 }
 
-pub(crate) type ButtonInteractionQuery<'w, 's, T> =
-    Query<'w, 's, (&'static Interaction, &'static T), (Changed<Interaction>, With<Button>)>;
+pub(crate) type InteractionQuery<'w, 's, T> =
+    Query<'w, 's, (&'static Interaction, &'static T), Changed<Interaction>>;
 
 /// Palette for widget interactions.
 #[derive(Component)]
@@ -28,7 +28,7 @@ impl InteractionPalette {
 fn apply_interaction_palette(
     mut interaction_query: Query<
         (&Interaction, &InteractionPalette, &mut BackgroundColor),
-        (Changed<Interaction>, With<Button>),
+        Changed<Interaction>,
     >,
 ) {
     for (interaction, palette, mut background) in &mut interaction_query {

--- a/src/util/ui/mod.rs
+++ b/src/util/ui/mod.rs
@@ -12,7 +12,7 @@ pub(super) fn plugin(app: &mut App) {
 
 pub(crate) mod prelude {
     pub(crate) use super::{
-        interaction::{ButtonInteractionQuery, InteractionPalette},
+        interaction::{InteractionPalette, InteractionQuery},
         palette as ui_palette,
         widgets::{RootContainers as _, Widgets as _},
     };

--- a/src/util/ui/mod.rs
+++ b/src/util/ui/mod.rs
@@ -1,21 +1,19 @@
 //! Collection of UI helpers.
 
-mod mouse_hover;
-mod palette;
+pub(crate) mod interaction;
+pub(crate) mod palette;
 mod widgets;
 
-use bevy::{color::palettes::tailwind, prelude::*};
-
-pub use palette::*;
-pub use widgets::*;
-
-pub(crate) type ButtonInteractionQuery<'w, 's, 'a, T> =
-    Query<'w, 's, (&'a Interaction, &'a T), (Changed<Interaction>, With<Button>)>;
+use bevy::prelude::*;
 
 pub(super) fn plugin(app: &mut App) {
-    // Sub plugins
-    app.add_plugins(mouse_hover::plugin);
+    app.add_plugins(interaction::plugin);
+}
 
-    // Other
-    app.insert_resource(ClearColor(BACKGROUND));
+pub(crate) mod prelude {
+    pub(crate) use super::{
+        interaction::{ButtonInteractionQuery, InteractionPalette},
+        palette as ui_palette,
+        widgets::{RootContainers as _, Widgets as _},
+    };
 }

--- a/src/util/ui/widgets.rs
+++ b/src/util/ui/widgets.rs
@@ -3,9 +3,9 @@
 use bevy::{ecs::system::EntityCommands, prelude::*};
 
 use super::{
-    mouse_hover::InteractionPalette,
+    interaction::InteractionPalette,
     palette::{
-        BUTTON_HOVERED_BACKGROUND, BUTTON_PRESSED_BACKGROUND, BUTTON_TEXT, LABEL_TEXT,
+        BACKGROUND, BUTTON_HOVERED_BACKGROUND, BUTTON_PRESSED_BACKGROUND, BUTTON_TEXT, LABEL_TEXT,
         NODE_BACKGROUND,
     },
 };
@@ -47,6 +47,7 @@ impl<'a, 'b> RootContainers for Commands<'a, 'b> {
                 position_type: PositionType::Absolute,
                 ..default()
             },
+            background_color: BACKGROUND.into(),
             ..default()
         })
     }


### PR DESCRIPTION
Fixes https://github.com/TheBevyFlock/bevy-template/issues/64.

This also removes `ClearColor` and instead uses the `BackgroundColor` component of `ui_root`.