### PR TITLE
Make splash screen image explicitly linear

### DIFF
--- a/src/screen/splash/mod.rs
+++ b/src/screen/splash/mod.rs
@@ -49,6 +49,8 @@ fn spawn_splash(mut commands: Commands, asset_server: Res<AssetServer>) {
                     image: UiImage::new(asset_server.load_with_settings(
                         "embedded://bevy_template/screen/splash/splash.png",
                         |settings: &mut ImageLoaderSettings| {
+                            // Make an exception for the splash image in case
+                            // `ImagePlugin::default_nearest()` is used for pixel art.
                             settings.sampler = ImageSampler::linear();
                         },
                     )),

--- a/src/screen/splash/mod.rs
+++ b/src/screen/splash/mod.rs
@@ -1,6 +1,10 @@
 //! A splash screen that plays briefly at startup.
 
-use bevy::{asset::embedded_asset, prelude::*};
+use bevy::{
+    asset::embedded_asset,
+    prelude::*,
+    render::texture::{ImageLoaderSettings, ImageSampler},
+};
 
 use super::Screen;
 use crate::ui_tools::prelude::*;
@@ -42,9 +46,12 @@ fn spawn_splash(mut commands: Commands, asset_server: Res<AssetServer>) {
                         width: Val::Percent(70.0),
                         ..default()
                     },
-                    image: UiImage::new(
-                        asset_server.load("embedded://bevy_template/screen/splash/splash.png"),
-                    ),
+                    image: UiImage::new(asset_server.load_with_settings(
+                        "embedded://bevy_template/screen/splash/splash.png",
+                        |settings: &mut ImageLoaderSettings| {
+                            settings.sampler = ImageSampler::linear();
+                        },
+                    )),
                     ..default()
                 },
             ));


### PR DESCRIPTION
If a user sets `DefaultPlugins.set(ImagePlugin::default_nearest())`, e.g. for a pixel art game, the splash screen image will look awful.

Explicitly specify a linear sampler for the splash screen image to guarantee that won't happen.