### PR TITLE
Fix Trunk builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,7 @@ jobs:
     needs: get-version
     env:
       TARGET: wasm32-unknown-unknown
-      PROFILE: wasm-release
+      PROFILE: release
       PLATFORM: web
       VERSION: ${{ needs.get-version.outputs.version }}
 
@@ -76,12 +76,7 @@ jobs:
 
       - name: Prepare package
         run: |
-          trunk build --profile="${{ env.PROFILE }}" --dist "${{ env.OUT_DIR }}"
-
-      - name: Optimize Wasm
-        uses: NiklasEi/wasm-opt-action@v2
-        with:
-          file: ${{ env.OUT_DIR }}/*.wasm
+          trunk build --release --dist "${{ env.OUT_DIR }}"
 
       - name: Compress package
         working-directory: ./build/${{ env.PACKAGE }}
@@ -112,7 +107,7 @@ jobs:
     needs: get-version
     env:
       TARGET: x86_64-unknown-linux-gnu
-      PROFILE: release
+      PROFILE: release-native
       PLATFORM: linux
       VERSION: ${{ needs.get-version.outputs.version }}
 
@@ -178,7 +173,7 @@ jobs:
     needs: get-version
     env:
       TARGET: x86_64-pc-windows-msvc
-      PROFILE: release
+      PROFILE: release-native
       PLATFORM: windows
       VERSION: ${{ needs.get-version.outputs.version }}
 
@@ -240,7 +235,7 @@ jobs:
     needs: get-version
     env:
       TARGET: x86_64-apple-darwin
-      PROFILE: release
+      PROFILE: release-native
       PLATFORM: macOS-intel
       VERSION: ${{ needs.get-version.outputs.version }}
       CFLAGS: -fno-stack-check
@@ -304,7 +299,7 @@ jobs:
     needs: get-version
     env:
       TARGET: aarch64-apple-darwin
-      PROFILE: release
+      PROFILE: release-native
       PLATFORM: macOS-apple-silicon
       VERSION: ${{ needs.get-version.outputs.version }}
       # MacOS 11.0 Big Sur is the first version to support universal binaries.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,9 +70,12 @@ jobs:
         with:
           targets: ${{ env.TARGET }}
 
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@v1.7.4
+
       - name: Install dependencies
         run: |
-          cargo install trunk
+          cargo binstall trunk --no-confirm
 
       - name: Prepare package
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,9 @@ opt-level = 1
 [profile.dev.package."*"]
 opt-level = 3
 
-# Enable more optimization in release mode at the cost of compile time.
+# The default profile is optimized for Wasm builds because
+# that's what [Trunk reads](https://github.com/trunk-rs/trunk/issues/605).
+# Optimize for size in wasm-release mode to reduce load times and bandwidth usage on web.
 [profile.release]
 # Compile the entire crate as one unit.
 # Significantly slows compile times, marginal improvements.
@@ -58,13 +60,17 @@ codegen-units = 1
 # Do a second optimization pass over the entire program, including dependencies.
 # Slightly slows compile times, marginal improvements.
 lto = "thin"
-
-# Optimize for size in wasm-release mode to reduce load times and bandwidth usage on web.
-[profile.wasm-release]
-# Use release profile as default values.
-inherits = "release"
 # Optimize with size in mind (also try "s", sometimes it is better).
 # This doesn't increase compilation times compared to -O3, great improvements.
 opt-level = "z"
 # Strip all debugging information from the binary to reduce file size.
 strip = "debuginfo"
+
+# Override some settings for native builds.
+[profile.native-release]
+# Use release profile as default values.
+inherits = "release"
+# Optimize with performance in mind.
+opt-level = 3
+# Keep debug information in the binary.
+strip = "none"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ opt-level = "z"
 strip = "debuginfo"
 
 # Override some settings for native builds.
-[profile.native-release]
+[profile.release-native]
 # Use release profile as default values.
 inherits = "release"
 # Optimize with performance in mind.

--- a/web/index.html
+++ b/web/index.html
@@ -7,7 +7,7 @@
     <link data-trunk rel="copy-dir" href="../assets"/>
     <link data-trunk rel="inline" href="style.css"/>
     <link data-trunk rel="inline" type="module" href="restart-audio-context.js"/>
-    <link data-trunk rel="rust" data-cargo-no-default-features href="../"/>
+    <link data-trunk rel="rust" data-cargo-no-default-features data-wasm-opt="s" href="../"/>
 </head>
 
 <body>


### PR DESCRIPTION
Trunk only reads the `release` profile, see https://github.com/trunk-rs/trunk/issues/780

Also: trunk can already to `wasm-opt`, so no need to have a CI step for that.
I also switched from `cargo install` to `cargo binstall` to not spend 5 minutes compiling trunk