### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,20 +18,16 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
-      - name: Cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.toml') }}
+        
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache target directory
+        uses: Leafwing-Studios/cargo-cache@v1
+
       - name: Install Dependencies
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+
       - name: Run cargo test
         run: cargo test --all-targets
 
@@ -43,22 +39,18 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
-      - name: Cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.toml') }}
+
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+
+      - name: Cache target directory
+        uses: Leafwing-Studios/cargo-cache@v1
+
       - name: Install Dependencies
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+
       - name: Run clippy
         run: cargo clippy --all-targets -- -D warnings
 
@@ -70,10 +62,15 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
+
+      - name: Cache target directory
+        uses: Leafwing-Studios/cargo-cache@v1
+
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
 
@@ -85,9 +82,15 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache target directory
+        uses: Leafwing-Studios/cargo-cache@v1
+
       - name: Install Dependencies
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+
       - name: Run cargo doc
         run: cargo doc --no-deps

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,9 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # Enable sccache to speed up builds.
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
 
 jobs:
   # Run cargo test --all-targets
@@ -97,7 +100,7 @@ jobs:
 
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.5
-        
+
       - name: Cache target directory
         uses: Leafwing-Studios/cargo-cache@v1
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,9 +18,12 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
-        
+
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.5
 
       - name: Cache target directory
         uses: Leafwing-Studios/cargo-cache@v1
@@ -45,6 +48,9 @@ jobs:
         with:
           components: clippy
 
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.5
+
       - name: Cache target directory
         uses: Leafwing-Studios/cargo-cache@v1
 
@@ -68,6 +74,9 @@ jobs:
         with:
           components: rustfmt
 
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.5
+
       - name: Cache target directory
         uses: Leafwing-Studios/cargo-cache@v1
 
@@ -86,6 +95,9 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.5
+        
       - name: Cache target directory
         uses: Leafwing-Studios/cargo-cache@v1
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  # Run cargo test
+  # Run cargo test --all-targets
   test:
     name: Test Suite
     runs-on: ubuntu-latest
@@ -33,9 +33,9 @@ jobs:
       - name: Install Dependencies
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Run cargo test
-        run: cargo test
+        run: cargo test --all-targets
 
-  # Run cargo clippy -- -D warnings
+  # Run cargo clippy --all-targets -- -D warnings --all-targets
   clippy_check:
     name: Clippy
     runs-on: ubuntu-latest
@@ -60,7 +60,7 @@ jobs:
       - name: Install Dependencies
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Run clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-targets -- -D warnings
 
   # Run cargo fmt --all -- --check
   format:
@@ -76,3 +76,16 @@ jobs:
           components: rustfmt
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
+
+# Run cargo doc --no-deps
+  doc:
+    name: Doc
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run cargo doc
+        run: cargo doc --no-deps

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,5 +87,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+      - name: Install Dependencies
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Run cargo doc
         run: cargo doc --no-deps

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,11 +9,11 @@ on:
 env:
   CARGO_TERM_COLOR: always
   # Enable sccache to speed up builds.
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
+  SCCACHE_GHA_ENABLED: true
+  RUSTC_WRAPPER: sccache
 
 jobs:
-  # Run cargo test --all-targets
+  # Run unit tests.
   test:
     name: Test Suite
     runs-on: ubuntu-latest
@@ -37,7 +37,7 @@ jobs:
       - name: Run cargo test
         run: cargo test --all-targets
 
-  # Run cargo clippy --all-targets -- -D warnings --all-targets
+  # Run clippy lints.
   clippy_check:
     name: Clippy
     runs-on: ubuntu-latest
@@ -86,7 +86,7 @@ jobs:
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
 
-# Run cargo doc --no-deps
+  # Check documentation.
   doc:
     name: Doc
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,9 @@ env:
   # Before enabling LFS, please take a look at GitHub's documentation for costs and quota limits:
   # https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-storage-and-bandwidth-usage
   USE_GIT_LFS: false
+  # Enable sccache to speed up builds.
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
 
 jobs:
   # Extract the version number from the pushed tag.
@@ -71,6 +74,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ env.TARGET }}
+
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.5
 
       - name: Cache target directory
         uses: Leafwing-Studios/cargo-cache@v1
@@ -138,6 +144,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ env.TARGET }}
+
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.5
 
       - name: Cache target directory
         uses: Leafwing-Studios/cargo-cache@v1
@@ -208,6 +217,9 @@ jobs:
         with:
           targets: ${{ env.TARGET }}
 
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.5
+
       - name: Cache target directory
         uses: Leafwing-Studios/cargo-cache@v1
 
@@ -268,6 +280,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
             targets: aarch64-apple-darwin
+
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.5
 
       - name: Cache target directory
         uses: Leafwing-Studios/cargo-cache@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,8 +31,8 @@ env:
   # https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-storage-and-bandwidth-usage
   USE_GIT_LFS: false
   # Enable sccache to speed up builds.
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
+  SCCACHE_GHA_ENABLED: true
+  RUSTC_WRAPPER: sccache
 
 jobs:
   # Extract the version number from the pushed tag.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,6 +72,9 @@ jobs:
         with:
           targets: ${{ env.TARGET }}
 
+      - name: Cache target directory
+        uses: Leafwing-Studios/cargo-cache@v1
+
       - name: Install cargo-binstall
         uses: cargo-bins/cargo-binstall@v1.7.4
 
@@ -135,6 +138,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ env.TARGET }}
+
+      - name: Cache target directory
+        uses: Leafwing-Studios/cargo-cache@v1
 
       - name: Install dependencies
         run: |
@@ -202,6 +208,9 @@ jobs:
         with:
           targets: ${{ env.TARGET }}
 
+      - name: Cache target directory
+        uses: Leafwing-Studios/cargo-cache@v1
+
       - name: Build binary
         run: |
           cargo build --profile="${{ env.PROFILE }}" --target="${{ env.TARGET }}" --no-default-features
@@ -260,6 +269,9 @@ jobs:
         with:
             targets: aarch64-apple-darwin
 
+      - name: Cache target directory
+        uses: Leafwing-Studios/cargo-cache@v1
+
       - name: Build binary for Apple Silicon
         run: |
           SDKROOT="$(xcrun -sdk macosx --show-sdk-path)" cargo build --profile="${{ env.PROFILE }}" --no-default-features --target=aarch64-apple-darwin
@@ -269,6 +281,9 @@ jobs:
         with:
           toolchain: stable
           targets: x86_64-apple-darwin
+
+      - name: Cache target directory
+        uses: Leafwing-Studios/cargo-cache@v1
 
       - name: Build binary for Apple x86_64
         run: |


### PR DESCRIPTION
- Add `--all-targets`, which is short for `--lib --bins --tests --benches --examples`
- Add `cargo doc` checks. I have found that using `cargo doc` for development can be useful to read my own documentation and understand what the heck I was thinking a month ago. As such, it would be nice to check it in the CI. I pass `--no-deps` to not compile the dependencies in that step
- Implement #122
	- Runs once for each macOS build
- Implement #118 
	- Runs only once for macOS